### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "A little tool for parsing articles from the web and extracting useful data from them"
 license = "MIT"
 license-file = "LICENSE"
+repository = "https://github.com/bsgbryan/parsicle"
 
 [dependencies]
 article_scraper = "2.1.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.